### PR TITLE
Scanner should accept both action.yml and action.yaml files

### DIFF
--- a/lib/actions.mjs
+++ b/lib/actions.mjs
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
 import { Octokit } from 'octokit';
 import chalk from 'chalk';
-import { logger, GITHUB_URL_RE, ACTION_NAME_REGEX, getFilesFromArchive, actionSteps, stepMatches, evaluateStepRule } from './utils.mjs';
+import { logger, GITHUB_URL_RE, ACTION_NAME_REGEX, getFilesFromArchive, actionSteps, stepMatches, evaluateStepRule, getActionFilePath, findActionFile } from './utils.mjs';
 import { SECRET_RULES } from "./rules/common/defs.mjs";
 import YAML from 'yaml';
 
@@ -335,7 +335,8 @@ class Action {
     let { groups: { owner, repo, ref } } = url.match(GITHUB_URL_RE);
     const foundrepo = await RepoCache.findOrCreate(owner, repo, ref);
     if (!foundrepo) return;
-    const action = await ActionCache.findOrCreate(foundrepo, "action.yml");
+    const actionPath = getActionFilePath();
+    const action = await ActionCache.findOrCreate(foundrepo, actionPath);
     return action;
   }
 
@@ -347,8 +348,8 @@ class Action {
     if (uses.startsWith('.')) {
       // uses: ./
       // relative to root of repo
-      const path = join(uses, "action.yml");
-      return await ActionCache.findOrCreate(repo, path);
+      const actionPath = getActionFilePath(uses);
+      return await ActionCache.findOrCreate(repo, actionPath);
     } else if (uses.startsWith("docker://")) {
       // docker hub
       logger.warn("uses: docker:// detected but not supported")
@@ -358,7 +359,8 @@ class Action {
       if (subPath === undefined) subPath = "";
       if (ref === undefined) ref = "";
       const repo = await RepoCache.findOrCreate(org, action, ref);
-      const newaction = await ActionCache.findOrCreate(repo, join(subPath, "action.yml"));
+      const actionPath = getActionFilePath(subPath);
+      const newaction = await ActionCache.findOrCreate(repo, actionPath);
       if (newaction.repo === undefined) {
         newaction.norepo = {
           uses,
@@ -382,7 +384,21 @@ class Action {
 
   async getFileContent() {
     if (this._contents !== undefined) return this._contents
-    this._contents = this.repo?.getFile(this.subpath) || "";
+
+    //Try to get the FileContent
+    this._contents = await this.repo?.getFile(this.subpath) || "";
+
+    //If the content is empty and the path ends with .yml, try .yaml as fallback
+    if (!this._contents && this.subpath.endsWith('.yml')) {
+      const yamlPath = this.subpath.replace(/\.yml$/, '.yaml');
+      this._contents = await this.repo?.getFile(yamlPath) || "";
+
+      //If we found content with .yaml extension, update the subpath
+      if(this._contents) {
+        this.subpath = yamlPath;
+      }
+    }
+    
     return this._contents;
   }
 

--- a/lib/utils.mjs
+++ b/lib/utils.mjs
@@ -4,6 +4,7 @@ import { extract } from 'tar-stream';
 import gunzip from 'gunzip-maybe';
 import { inspect } from 'util';
 import chalk from 'chalk';
+import { join } from 'node:path';
 import winston from 'winston';
 
 export const GITHUB_URL_RE = new RegExp("https://github.com/(?<owner>[^/]+)/(?<repo>[^/]+)(/commit/(?<ref>[0-9a-z-.]+))?")
@@ -205,4 +206,31 @@ function recursiveEvaluate(rule, step, regexpgroup) {
 
 export function evaluateStepRule(rule, step, regexpgroup = false) {
   return recursiveEvaluate(rule, step, regexpgroup);
+}
+
+//Helper function to find action file with either .yml or .yaml extension
+//This function returns the preferred path
+export function getActionFilePath(basePath = "") {
+  //Prefer .yml over .yaml (Gihubs convention)
+  return join(basePath, "action.yml");
+}
+
+//Helper function to check if action file exists (fallback -> action.yaml)
+export async function findActionFile(repo, basePath = "") {
+  await repo.getActions();
+  const ymlPath = join(basePath, "action.yml");
+  const yamlPath = join(basePath, "action.yaml");
+
+  //Check if action.yml exists in the repository files
+  if(repo._actionfiles && repo._actionfiles[ymlPath]) {
+    return ymlPath;
+  }
+
+  //Check if action.yaml exists in the repository files
+  if(repo._actionfiles && repo._actionfiles[yamlPath]) {
+    return yamlPath;
+  }
+
+  //If neither exists return null
+  return null;
 }


### PR DESCRIPTION
This PR aims to resolve the [Issue](https://github.com/snyk-labs/github-actions-scanner/issues/15) 
The idea here is to look for action.yaml as fallback when action.yml does not exist (based on Github's precedence) 